### PR TITLE
Make apis selectable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ VENV_RUN = . $(VENV_DIR)/bin/activate
 AWS_STS_URL = http://central.maven.org/maven2/com/amazonaws/aws-java-sdk-sts/1.11.14/aws-java-sdk-sts-1.11.14.jar
 ES_URL = https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/zip/elasticsearch/2.3.3/elasticsearch-2.3.3.zip
 TMP_ARCHIVE_ES = /tmp/localstack.es.zip
+APIS=s3 sns sqs es apigateway dynamodb kinesis dynamodbstreams firehose lambda
 
 usage:             ## Show this help
 	@fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//' | sed -e 's/##//'
@@ -42,7 +43,7 @@ coveralls:         ## Publish coveralls metrics
 	($(VENV_RUN); coveralls)
 
 infra:             ## Manually start the local infrastructure for testing
-	($(VENV_RUN); localstack/mock/infra.py)
+	($(VENV_RUN); localstack/mock/infra.py $(APIS))
 
 web:               ## Start web application (dashboard)
 	($(VENV_RUN); bin/localstack web --port=8081)

--- a/bin/localstack
+++ b/bin/localstack
@@ -4,7 +4,7 @@
 Main script for starting localstack components.
 
 Usage:
-  localstack infra
+  localstack infra [<api>...]
   localstack web [ --port=<port> ]
   localstack (-h | --help)
 
@@ -29,7 +29,11 @@ if __name__ == "__main__":
 
     if args['infra']:
         print('Starting local dev environment. CTRL-C to quit.')
-        infra.start_infra()
+        apis = args['<api>']
+        if apis:
+            infra.start_infra(apis=apis)
+        else:
+            infra.start_infra()
     elif args['web']:
         import localstack.dashboard.api
         port = args['--port'] or DEFAULT_PORT

--- a/localstack/mock/infra.py
+++ b/localstack/mock/infra.py
@@ -1,5 +1,16 @@
 #!/usr/bin/env python
 
+"""
+Main script for starting localstack components.
+
+Usage:
+  localstack [<api>...]
+  localstack (-h | --help)
+
+Options:
+  -h --help     Show this screen.
+"""
+
 import os
 import re
 import sys
@@ -418,5 +429,12 @@ def dynamodb_extract_keys(item, table_name):
 
 
 if __name__ == '__main__':
+    from docopt import docopt
+    args = docopt(__doc__)
+
     print('Starting local dev environment. CTRL-C to quit.')
-    start_infra()
+    apis = args['<api>']
+    if apis:
+        start_infra(apis=apis)
+    else:
+        start_infra()


### PR DESCRIPTION
The following PR:
 - Allows running just certain _apis_ from input 

Examples:
`$> make infra kinesis firehose lambda`

`$> ./bin/localstack infra s3 kinesis firehose lambda`