### PR TITLE
Allow Lambdas to use __file__

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ make web
 
 ## Change Log
 
+* v0.2.4: Allow Lambdas to use __file__ (import from file instead of exec'ing)
 * v0.2.3: Improve Kinesis/KCL auto-checkpointing (leases in DDB)
 * v0.2.0: Speed up installation time by lazy loading libraries
 * v0.1.19: Pass shard_id in records sent from KCL process

--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ if __name__ == '__main__':
 
     setup(
         name='localstack',
-        version='0.2.3',
+        version='0.2.4',
         description='Provides an easy-to-use test/mocking framework for developing Cloud applications',
         author='Waldemar Hummer (Atlassian)',
         author_email='waldemar.hummer@gmail.com',


### PR DESCRIPTION
Allow Lambdas to use `__file__` - import from file instead of exec'ing. Fix #10 