### PR TITLE
Updated README.md to specify Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ missing functionality on top of them:
 ## Requirements
 
 * `make`
-* `python`
+* `python 2`
 * `pip` (python package manager)
 * `npm` (node.js package manager)
 * `java`/`javac` (Java runtime environment and compiler)


### PR DESCRIPTION
The code isn't compatible with Python 3, so should specify Python 2 until the whole project can be properly supported.

For now, setup.py line 40 doesn't follow Python 3 PEP 3105 print standard.