### PR TITLE
Fix travis configuration for aws-cli

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,9 @@ addons:
 env:
   global:
     - JAVA_HOME=/usr/lib/jvm/java-8-oracle
+    - AWS_ACCESS_KEY_ID=foobar
+    - AWS_SECRET_ACCESS_KEY=foobar
+    - AWS_DEFAULT_REGION=us-east-1
 
 install:
   - travis_wait 20 make install


### PR DESCRIPTION
Fix travis configuration for aws-cli (missing environment variables)