### PR TITLE
Improving Lambda APIs

### DIFF
--- a/localstack/mock/apis/lambda_api.py
+++ b/localstack/mock/apis/lambda_api.py
@@ -196,7 +196,8 @@ def run_lambda(func, event, context, func_arn, suppress_output=False):
             event_string = json.dumps(event).replace("'", "\\'")
             result = run(cmd, env_vars={'AWS_LAMBDA_EVENT_BODY': event_string})
         else:
-            if func.func_code.co_argcount == 2:
+            function_code = func.func_code if 'func_code' in func.__dict__ else func.__code__
+            if function_code.co_argcount == 2:
                 result = func(event, context)
             else:
                 raise Exception('Expected handler function with 2 parameters, found %s' % func.func_code.co_argcount)
@@ -204,7 +205,7 @@ def run_lambda(func, event, context, func_arn, suppress_output=False):
         if suppress_output:
             sys.stdout = stdout_
             sys.stderr = stderr_
-        print("ERROR executing Lambda function: %s" % traceback.format_exc(e))
+        print("ERROR executing Lambda function: %s" % traceback.format_exc())
     finally:
         if suppress_output:
             sys.stdout = stdout_
@@ -339,9 +340,14 @@ def create_function():
               in: body
     """
     try:
-        data = json.loads(request.data)
+        data = json.loads(to_str(request.data))
         lambda_name = data['FunctionName']
         arn = func_arn(lambda_name)
+        if arn in lambda_arn_to_handler:
+            result = {'Type': 'User', 'message': 'Function already exist: %s' % lambda_name}
+            headers = {'x-amzn-errortype': 'ResourceConflictException'}
+            response = make_response((jsonify(result), 409, headers))
+            return response
         lambda_arn_to_handler[arn] = data['Handler']
         lambda_arn_to_runtime[arn] = data['Runtime']
         code = data['Code']
@@ -406,15 +412,8 @@ def delete_function(function):
             - name: 'request'
               in: body
     """
-    if request.data:
-        data = json.loads(request.data)
     arn = func_arn(function)
-    try:
-        lambda_arn_to_function.pop(arn)
-    except KeyError:
-        print('Function Cannot be Found')
-        return jsonify({'Error': 'Function not Found'})
-
+    lambda_arn_to_function.pop(arn)
     lambda_arn_to_cwd.pop(arn)
     lambda_arn_to_handler.pop(arn)
     i = 0
@@ -437,7 +436,7 @@ def update_function_code(function):
             - name: 'request'
               in: body
     """
-    data = json.loads(request.data)
+    data = json.loads(to_str(request.data))
     set_function_code(data, function)
     result = {}
     return jsonify(result)
@@ -453,7 +452,7 @@ def get_function_code(function):
     arn = func_arn(function)
     lambda_cwd = lambda_arn_to_cwd[arn]
     tmp_file = '%s/%s' % (lambda_cwd, LAMBDA_ZIP_FILE_NAME)
-    return Response(load_file(tmp_file),
+    return Response(load_file(tmp_file, mode="rb"),
             mimetype='application/zip',
             headers={'Content-Disposition': 'attachment; filename=lambda_archive.zip'})
 
@@ -467,7 +466,7 @@ def update_function_configuration(function):
             - name: 'request'
               in: body
     """
-    data = json.loads(request.data)
+    data = json.loads(to_str(request.data))
     arn = func_arn(function)
     if data.get('Handler'):
         lambda_arn_to_handler[arn] = data['Handler']
@@ -488,7 +487,7 @@ def invoke_function(function):
     """
     data = {}
     try:
-        data = json.loads(request.data)
+        data = json.loads(to_str(request.data))
     except Exception as e:
         pass
     arn = func_arn(function)
@@ -506,20 +505,16 @@ def list_event_source_mappings():
     """ List event source mappings
         ---
         operationId: 'listEventSourceMappings'
-        parameters:
-            - name: 'request'
     """
-    # needs to check request body first
-
     event_source_arn = request.args.get('EventSourceArn')
     function_name = request.args.get('FunctionName')
 
     mappings = event_source_mappings
     if event_source_arn:
-        mappings = [m for m in mappings if event_source_arn == m['EventSourceArn']]
+        mappings = [m for m in mappings if event_source_arn == m.get('EventSourceArn')]
     if function_name:
         function_arn = func_arn(function_name)
-        mappings = [m for m in mappings if function_arn == m['FunctionArn']]
+        mappings = [m for m in mappings if function_arn == m.get('FunctionArn')]
 
     response = {
         'EventSourceMappings': mappings
@@ -536,7 +531,7 @@ def create_event_source_mapping():
             - name: 'request'
               in: body
     """
-    data = json.loads(request.data)
+    data = json.loads(to_str(request.data))
     mapping = add_event_source(data['FunctionName'], data['EventSourceArn'])
     return jsonify(mapping)
 
@@ -566,9 +561,6 @@ def delete_event_source_mapping(mapping_uuid):
     """ Create new event source mapping
         ---
         operationId: 'deleteEventSourceMapping'
-        parameters:
-            - name: 'request'
-              in: body
     """
     # uuid = data.get('UUID')
     if not mapping_uuid:
@@ -589,4 +581,3 @@ if __name__ == '__main__':
     port = DEFAULT_PORT_LAMBDA
     print("Starting server on port %s" % port)
     serve(port)
-

--- a/localstack/mock/apis/lambda_api.py
+++ b/localstack/mock/apis/lambda_api.py
@@ -413,7 +413,13 @@ def delete_function(function):
               in: body
     """
     arn = func_arn(function)
-    lambda_arn_to_function.pop(arn)
+    try:
+        lambda_arn_to_function.pop(arn)
+    except KeyError:
+        result = {'Type': 'User', 'message': 'Function does not exist: %s' % function}
+        headers = {'x-amzn-errortype': 'ResourceNotFoundException'}
+        response = make_response((jsonify(result), 404, headers))
+        return response
     lambda_arn_to_cwd.pop(arn)
     lambda_arn_to_handler.pop(arn)
     i = 0


### PR DESCRIPTION
- `delete_function` will no longer error out (500 internal error) when deleting a function that doesn't exist 
- added [update_event_source_mapping](http://boto3.readthedocs.io/en/latest/reference/services/lambda.html#Lambda.Client.update_event_source_mapping)
- added [delete_event_source_mapping](http://boto3.readthedocs.io/en/latest/reference/services/lambda.html#Lambda.Client.delete_event_source_mapping)
- `list_event_source_mappings` is modified per [AWS doc](https://docs.aws.amazon.com/lambda/latest/dg/API_ListEventSourceMappings.html), it will return all mappings unless `EventSourceArn` and/or `FunctionName` are in the request, in which case only matched items will be returned. This helps the user decide if a specific mapping already exists before calling `update_event_source_mapping`